### PR TITLE
Update functions

### DIFF
--- a/content/usr/local/include/xbian-config/modules/network/functions
+++ b/content/usr/local/include/xbian-config/modules/network/functions
@@ -481,6 +481,7 @@ function scanWLANNetworksFn() {
 #			WLAN[3]=$(echo $LINE | awk -F"Quality=" '{print $2}' | cut -d'/' -f1);
 			WLAN[3]=$(echo $LINE | awk -F"Quality=" '{print $2}' | cut -d' ' -f1);
 			[ "${WLAN[3]}" = '' ] && WLAN[3]=$(echo $LINE | awk -F"Signal level=" '{print $2}');
+			[ "${WLAN[3]}" = '' ] && WLAN[3]=$(echo $LINE | awk -F"Signal level:" '{print $2}' | cut -d' ' -f1));
 			WLAN[3]=$((100*${WLAN[3]}))
                 fi
 	done;


### PR DESCRIPTION
Fix for a error when Scanning wlan through xbian-config
Error: 

> /usr/local/include/xbian-config/modules/network/functions: line 484: 100_: syntax error: operand expected (error token is "_")
