### PR TITLE
update po file from transifex

### DIFF
--- a/.tx/config
+++ b/.tx/config
@@ -1,0 +1,9 @@
+[main]
+host = https://www.transifex.com
+
+[xbian-translation.xbianpo]
+file_filter = content/usr/local/include/xbian-config/gettext/xbian.<lang>.po
+source_file = content/usr/local/include/xbian-config/gettext/xbian.en.po
+source_lang = en
+type = PO
+

--- a/update.translation
+++ b/update.translation
@@ -1,0 +1,1 @@
+tx pull -fa


### PR DESCRIPTION
It add a dependency : 
apt-get install transifex-client

after to update po file in package, just run in root package folder 
tx pull -a

it's also possible to auto-update transiflex from a pot file on github, but will look at this later

also you nee to create a file (~/.transifexrc), like explain here 
http://docs.transifex.com/developer/client/setup#transifexrc

i will send by mail mine, as i don't find yet hot to create a xbian user as admin in transifex

are you ok with this solution?
