### PR TITLE
Additional check before enabling ssh root login

### DIFF
--- a/content/usr/local/include/xbian-config/modules/sshroot/functions
+++ b/content/usr/local/include/xbian-config/modules/sshroot/functions
@@ -36,7 +36,12 @@ function rootPasswordSetFn() {
 #  - 1: Success
 #  - 0: Failed
 function enableSSHRootLoginFn() {
-	sed -i 's/PermitRootLogin no/PermitRootLogin yes/g' /etc/ssh/sshd_config
+        if [ $(grep -c "PermitRootLogin without-password" /etc/ssh/sshd_config) -ge 0 ]; then
+                sed -i 's/PermitRootLogin without-password/PermitRootLogin yes/g' /etc/ssh/sshd_config
+        elif [ $(grep -c "PermitRootLogin no" /etc/ssh/sshd_config) -ge 0 ]; then
+                sed -i 's/PermitRootLogin no/PermitRootLogin yes/g' /etc/ssh/sshd_config
+        fi
+
 	isSSHRootLoginEnabledFn
 	return $?;
 }


### PR DESCRIPTION
In the CuBox-I XBian image, the default PermitRootLogin is `without-password`. Therefor enabling it in xbian-config doesn't work when we only check the `no` parameter. This commit checks for both `without-password` and `no` parameter and changes it to `yes`
