### PR TITLE
btrfs-auto-snapshot fails because $EXCLUDESUB is empty (fixed #35)

### DIFF
--- a/content/etc/cron.daily/xbian-daily-btrfs
+++ b/content/etc/cron.daily/xbian-daily-btrfs
@@ -14,4 +14,10 @@ while initctl list | grep "^xbian-xbmc-player" | grep -q "start/running"; do
   sleep 300 # 5 minutes
 done
 
-btrfs-auto-snapshot -l daily -k $KEEPDAYS -v -x $EXCLUDESUB //
+if [ -z "$EXCLUDESUB" ];
+then
+  TMPEXCLUDESUB=
+else
+  TMPEXCLUDESUB="-x $EXCLUDESUB"
+fi
+btrfs-auto-snapshot -l daily -k $KEEPDAYS -v $TMPEXCLUDESUB //


### PR DESCRIPTION
The daily script `/etc/cron.daily/xbian-daily-btrfs` fails because the $EXCLUDESUB in `/etc/default/xbian-snap` is empty by default and then it runs `btrfs-auto-snapshot -l daily -k $KEEPDAYS -v -x //` and ends with:

```
/etc/cron.daily/xbian-daily-btrfs:
Error: The filesystem argument list is empty.
run-parts: /etc/cron.daily/xbian-daily-btrfs exited with return code 133
```

This fixes the issue.