### PR TITLE
fix cron.weekly for "Error: The filesystem argument list is empty."

### DIFF
--- a/content/etc/cron.weekly/xbian-weekly-btrfs
+++ b/content/etc/cron.weekly/xbian-weekly-btrfs
@@ -12,4 +12,10 @@ while initctl list | grep "^xbian-xbmc-player" | grep -q "start/running"; do
   sleep 300 # 5 minutes
 done
 
-btrfs-auto-snapshot -l weekly -k $KEEPWEEKS -v -x $EXCLUDESUB //
+if [ -z "$EXCLUDESUB" ];
+then
+  TMPEXCLUDESUB=
+else
+  TMPEXCLUDESUB="-x $EXCLUDESUB"
+fi
+btrfs-auto-snapshot -l weekly -k $KEEPWEEKS -v $TMPEXCLUDESUB //


### PR DESCRIPTION
This is the same fix as in cron.daily but this time for weekly.

See #36 